### PR TITLE
Add Ballerina Project Overview

### DIFF
--- a/tool-plugins/vscode/src/extension.ts
+++ b/tool-plugins/vscode/src/extension.ts
@@ -24,6 +24,7 @@ import { activate as activateDiagram } from './diagram';
 import { activate as activateBBE } from './bbe';
 import { activate as activateDocs } from './docs';
 import { activate as activateTraceLogs } from './trace-logs';
+import { activate as activateTreeView } from './project-tree-view';
 import { activateDebugConfigProvider } from './debugger';
 import { activateTestRunner } from './test-runner';
 import { activate as activateProjectFeatures } from './project';
@@ -77,5 +78,7 @@ export function activate(context: ExtensionContext): Promise<any> {
         // Enable Ballerina Project related features
         activateProjectFeatures(ballerinaExtInstance);
         activateOverview(ballerinaExtInstance);
+        // Enable Ballerina Project Overview
+        activateTreeView(ballerinaExtInstance);
     });
 }

--- a/tool-plugins/vscode/src/project-tree-view/activator.ts
+++ b/tool-plugins/vscode/src/project-tree-view/activator.ts
@@ -1,0 +1,16 @@
+import * as vscode from 'vscode';
+
+import { BallerinaExtension } from '../core';
+import { ProjectTreeProvider } from './project-overview';
+
+export function activate(ballerinaExtInstance: BallerinaExtension) {
+    ballerinaExtInstance.onReady().then(() => {
+        const projectTreeProvider = new ProjectTreeProvider(ballerinaExtInstance);
+        vscode.window.registerTreeDataProvider('ballerinaProjectTree', projectTreeProvider);
+
+        vscode.commands.registerCommand('extension.openPackageOnNpm',(testing) => {
+            //TODO Command Execute Logic
+            console.log(testing);
+        });
+    });
+}

--- a/tool-plugins/vscode/src/project-tree-view/index.ts
+++ b/tool-plugins/vscode/src/project-tree-view/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+ 
+export * from './activator';

--- a/tool-plugins/vscode/src/project-tree-view/project-overview.ts
+++ b/tool-plugins/vscode/src/project-tree-view/project-overview.ts
@@ -1,0 +1,160 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+
+import { BallerinaExtension, ExtendedLangClient } from '../core/index';
+import { ProjectTreeElement } from './project-tree';
+
+/**
+ * This class will provide Tree Data required to draw the Ballerina Project Overview 
+ * on the explorer panel. 
+ */
+export class ProjectTreeProvider implements vscode.TreeDataProvider<ProjectTreeElement> {
+
+    private _onDidChangeTreeData: vscode.EventEmitter<ProjectTreeElement | undefined> = new vscode.EventEmitter<ProjectTreeElement | undefined>();
+    readonly onDidChangeTreeData: vscode.Event<ProjectTreeElement | undefined> = this._onDidChangeTreeData.event;
+    private langClient?: ExtendedLangClient;
+    private sourceRoot?: string;
+    private balProjectTree: TreeStructure = {};
+
+    constructor(context: BallerinaExtension) {
+        if (vscode.window.activeTextEditor) {
+            const currentUri = vscode.window.activeTextEditor.document.fileName;
+
+            this.langClient = context.langClient;
+            this.sourceRoot = this.getSourceRoot(currentUri, path.parse(currentUri).root);
+
+            this._onDidChangeTreeData.fire();
+        }
+    }
+
+    refresh(): void {
+		this._onDidChangeTreeData.fire();
+	}
+
+    getTreeItem(element: ProjectTreeElement): vscode.TreeItem | Thenable<vscode.TreeItem> {
+        return element;
+    }
+
+    getChildren(element?: ProjectTreeElement | undefined): vscode.ProviderResult<ProjectTreeElement[]> {
+        if (!element) {
+            return this.getProjectStructure();
+        } else {
+            return this.getTreeEl(element);
+        }
+    }
+
+    private getProjectStructure(): Promise<any> {
+        return new Promise<any>(resolve => {
+            if (this.langClient && this.sourceRoot) {
+                this.langClient.getProjectAST(vscode.Uri.file(this.sourceRoot).toString()).then((result: any) => {
+                    if (result.modules) {
+                        let treeNode: ProjectTreeElement[] = [];
+                        this.balProjectTree = this.buildProjectTree(result.modules);
+                        Object.keys(this.balProjectTree).map((node: any) => {
+                            treeNode.push(new ProjectTreeElement(node,1,{
+                                command: "ballerina.executeTreeElement",
+                                title: "Execute Tree Command",
+                                arguments: [node]
+                            }));
+                        });
+                        treeNode.sort((node1, node2) => node1.label.localeCompare(node2.label));
+                        resolve(treeNode);
+                    }
+                });
+            }
+        });
+    }
+
+    private buildProjectTree(treeItem: any): TreeStructure {
+        let projectTree: TreeStructure = {};
+        Object.keys(treeItem).map(item => {
+            if (treeItem[item].hasOwnProperty("compilationUnits")) {
+                projectTree[item] = this.buildProjectTree(treeItem[item].compilationUnits);
+            } else if (treeItem[item].hasOwnProperty("ast")) {
+                let nodes = treeItem[item].ast.topLevelNodes;
+                nodes.map((node: any) => {
+                    if (node.kind === "Service") {
+                        let resources: TreeStructure = {};
+                        if (node.resources && node.resources.length > 0) {
+                            node.resources.map((res: any) => {
+                                Object.defineProperty(resources, res.name.value, {
+                                    writable: true,
+                                    enumerable: true,
+                                    configurable: true
+                                });
+                            });
+                        }
+                        projectTree[node.name.value] = resources;
+                    }
+
+                    if (node.kind === "Function") {
+                        Object.defineProperty(projectTree, node.name.value, {
+                            writable: true,
+                            enumerable: true,
+                            configurable: true
+                        });
+                    } 
+                });
+            }
+        });
+        return projectTree;
+    }
+
+    private getTreeEl(parentEl: ProjectTreeElement): ProjectTreeElement[] {
+        let projectTree = this.balProjectTree;
+        let elementTree: ProjectTreeElement[] = [];
+
+        Object.keys(projectTree).map((key) => {
+            let element = projectTree[key];
+            if (key === parentEl.label) {
+                Object.keys(element).map(children => {
+                    elementTree.push(new ProjectTreeElement(children,1));
+                });
+            } else {
+                let treeObj = this.getTreeForKey(element, parentEl.label);
+                Object.keys(treeObj).map(children => {
+                    elementTree.push(new ProjectTreeElement(children,1));
+                });
+            }
+        });
+
+        return elementTree;
+    }
+
+    private getTreeForKey(obj: any, searchKey: string): any {
+        let matchedObjTree = {};
+        Object.keys(obj).map(key => {
+            if (key === searchKey && obj[searchKey] !== undefined) {
+                matchedObjTree = obj[searchKey];
+            }
+        });
+        return matchedObjTree;
+    }
+
+    /**
+     * Util method to get Ballerina project root.
+     * 
+     * @param currentPath - current active path
+     * @param root - root path
+     */
+    private getSourceRoot(currentPath: string, root: string): string|undefined {
+        if (fs.existsSync(path.join(currentPath, '.ballerina'))) {
+            if (currentPath !== os.homedir()) {
+                return currentPath;
+            }
+        }
+    
+        if (currentPath === root) {
+            return;
+        }
+    
+        return this.getSourceRoot(path.dirname(currentPath), root);
+    }
+    
+}
+
+interface TreeStructure {
+    [key: string]: any;
+}

--- a/tool-plugins/vscode/src/project-tree-view/project-tree.ts
+++ b/tool-plugins/vscode/src/project-tree-view/project-tree.ts
@@ -1,0 +1,14 @@
+import * as vscode from 'vscode';
+
+/**
+ * This class is a container class for Tree data required for Ballerina Project Overview.
+ */
+export class ProjectTreeElement extends vscode.TreeItem {
+    constructor(
+		public readonly label: string,
+        public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+        public readonly command?: vscode.Command
+	) {
+		super(label, collapsibleState);
+	}
+}


### PR DESCRIPTION
## Purpose
> This PR will add Ballerina Project Overview to Ballerina VSCode plugin which will show the project structure in a tree view on the Explorer view of VSCode.

![wI4fcx4mjx](https://user-images.githubusercontent.com/11191791/61025989-dfcfb500-a3cf-11e9-9d84-1e84dfb34cba.gif)
